### PR TITLE
Support more OSs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-18.04, ubuntu-16.04, macos-latest, windows-latest]
         node-version: [12.x]
     steps:
       - name: Checkout


### PR DESCRIPTION
Add virtual environments(OS): Windows, macOS, Ubuntu.

See also:
- [Virtual environments for GitHub-hosted runners](http://j.mp/39h8yLH)